### PR TITLE
apd010

### DIFF
--- a/src/screens/ApodScreen.js
+++ b/src/screens/ApodScreen.js
@@ -31,7 +31,12 @@ export default class ApodScreen extends Component {
 
   getNewApod(date) {
     {/* '2007-12-21' use that date to test horizontal img*/}
-    var apodDate = date == 'today' ? this.createTodaysDate() : this.getRandomApodDate();
+    var apodDate = date;
+    if (date === 'today') {
+        apodDate = this.createTodaysDate();
+    }else if (date === 'random') {
+        apodDate = this.getRandomApodDate();
+    }
     firebase.app.database().ref(`apods/${apodDate}`).on('value', (snapshot) => {
          if (snapshot.exists()) {
             this.setState({
@@ -48,7 +53,7 @@ export default class ApodScreen extends Component {
     axios.get('https://api.nasa.gov/planetary/apod', {
         params: {
           api_key: APOD_API_KEY,
-          date: apodDate
+          date: apodDate === 'today' ? '' : apodDate
         }
     })
     .then(( {data} ) =>  {


### PR DESCRIPTION
- Adjust ApodScreen to accept other dates than just today and random.
- Set date parameter to an empty string if the date is today. It fixes the problem when todays apod has not been added yet.